### PR TITLE
Add SMB hash backup proposal

### DIFF
--- a/FEATURE_PROPOSAL.md
+++ b/FEATURE_PROPOSAL.md
@@ -49,3 +49,8 @@ This document outlines proposed enhancements for the RoutR_MauraDr project.
 ## 12. Expanded CVE Dataset Integration
 - Extend the vulnerability lookup to include community-maintained IoT and router exploit databases.
 - Allow offline synchronization of CVE data so scans work without Internet access.
+
+## 13. SMB Hash Backup and Alerting
+- Leverage the new `web/tooling/smb_hash.py` script to automatically back up Samba password hashes.
+- Provide a CLI option and REST endpoint to schedule periodic backups.
+- Notify administrators when hash files are modified unexpectedly.


### PR DESCRIPTION
## Summary
- update the feature proposal with an SMB hash backup and alerting idea

## Testing
- `python3 -m py_compile web/tooling/smb_hash.py`

## Summary by Sourcery

Add a new SMB hash backup and alerting proposal to the feature specification.

New Features:
- Propose automated backup of Samba password hashes using web/tooling/smb_hash.py
- Outline scheduling of periodic backups via CLI option and REST endpoint
- Define alerting mechanism for unexpected modifications to hash files

Documentation:
- Extend FEATURE_PROPOSAL.md with a new section for SMB hash backup and alerting