### PR TITLE
Fix tests by cleaning config and plugin

### DIFF
--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -4,28 +4,16 @@ import unittest
 MODULES = [
     'web.src.gui',
     'web.src.integrations.vuln_scanners',
-
     'web.src.integrations.shodan',
     'web.src.integrations.wigle',
-    'web.src.firmware',
-    'web.src.scheduler',
-
-
     'web.src.integrations.shodan_client',
-    'web.src.firmware',
-    'web.src.scheduler',
-
     'web.src.firmware',
     'web.src.scheduler',
     'web.src.notifications',
     'web.src.network_info',
     'web.src.router_ssh',
     'web.src.quick_scan',
-    'web.src.net_services'
-
-
-
-    'web.src.notifications'
+    'web.src.net_services',
 ]
 
 

--- a/web/config.json
+++ b/web/config.json
@@ -1,18 +1,4 @@
 {
-    "scoring_weights": {
-        "vuln_penalty": 15,
-        "port_penalty": 5,
-        "creds_penalty": 10,
-        "patch_penalty": 5,
-        "high_risk_penalty": 3,
-        "critical_vuln_penalty": 20,
-        "cvss_penalty_factor": 1
-    },
-    "high_risk_ports": [21, 22, 23, 25, 53, 139, 445, 1433, 3306, 3389, 5900],
-    "database": "smb_enum.db",
-    "cve_api_timeout": 10,
-    "shodan_api_key": "",
-    "wigle": {"username": "", "password": ""}
   "scoring_weights": {
     "vuln_penalty": 15,
     "port_penalty": 5,
@@ -22,21 +8,10 @@
     "critical_vuln_penalty": 20,
     "cvss_penalty_factor": 1
   },
-  "high_risk_ports": [
-    21,
-    22,
-    23,
-    25,
-    53,
-    139,
-    445,
-    1433,
-    3306,
-    3389,
-    5900
-  ],
+  "high_risk_ports": [21, 22, 23, 25, 53, 139, 445, 1433, 3306, 3389, 5900],
   "database": "smb_enum.db",
   "cve_api_timeout": 10,
   "shodan_api_key": "",
+  "wigle": {"username": "", "password": ""},
   "default_shodan_query": "net:192.168.1.0/24"
 }

--- a/web/src/plugins/shodan_import.py
+++ b/web/src/plugins/shodan_import.py
@@ -1,14 +1,4 @@
-"""Plugin to import results from Shodan."""
-from ..integrations.shodan import ShodanClient
-
-NAME = "ShodanImport"
-
-client = ShodanClient()
-
-def register():
-    return {"message": "Shodan plugin loaded", "api_key_set": bool(client.api_key)}
-  """Plugin to import scan results from Shodan."""
-
+"""Plugin to import scan results from Shodan."""
 from ..integrations import shodan_client
 from ..config import config
 
@@ -22,3 +12,4 @@ def register():
     query = config.get("default_shodan_query", "net:192.168.1.0/24")
     results = shodan_client.shodan_search(query, api_key)
     return {"count": len(results), "sample": results[:5]}
+


### PR DESCRIPTION
## Summary
- remove duplicated entries in test modules list
- clean up Shodan import plugin
- repair broken config.json

## Testing
- `./runtests.sh`

## Summary by Sourcery

Repair test suite by removing duplicate module entries, fix configuration file, and tidy up Shodan import plugin code

Bug Fixes:
- Correct syntax in web/config.json to restore valid configuration

Enhancements:
- Clean up web/src/plugins/shodan_import.py by removing extraneous blank lines

Tests:
- Eliminate duplicate entries in MODULES list of tests/test_new_modules.py