### PR TITLE
Add config backup utility and clean proposals

### DIFF
--- a/FEATURE_PROPOSAL.md
+++ b/FEATURE_PROPOSAL.md
@@ -78,21 +78,13 @@ This document outlines proposed enhancements for the RoutR_MauraDr project.
 - Generate interactive network topology maps from scan results.
 - Offer export options to PNG or HTML for easy sharing.
 
-## 18. Automated Firmware Bug Search
-- Combine firmware detection with offline CVE data to flag known exploits automatically.
-- Attempt SSH login with default credentials when a vulnerable firmware version is found.
-
-## 19. Visual Network Mapping
-- Generate a graphical map of discovered hosts and connections for easier analysis.
-- Offer export options to PNG or SVG for integration into reports.
-
 ## 20. Community Plugin Repository
 - Allow installation of third-party scanning modules from a curated list.
 - Provide version checks and signatures to maintain security when fetching plugins.
 
-## 20. Community Plugin Repository
-- Package plugins with metadata so they can be shared easily.
-- Provide a helper script to submit plugins to a community repository.
 ## 21. Shodan Scan Import
 - Integrate a Shodan API client to import search results and correlate them with local scans.
+
+## 22. Configuration Backup and Restore
+- Add commands to back up router configuration files and verify them against baselines.
 

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -4,28 +4,17 @@ import unittest
 MODULES = [
     'web.src.gui',
     'web.src.integrations.vuln_scanners',
-
     'web.src.integrations.shodan',
     'web.src.integrations.wigle',
-    'web.src.firmware',
-    'web.src.scheduler',
-
-
     'web.src.integrations.shodan_client',
-    'web.src.firmware',
-    'web.src.scheduler',
-
     'web.src.firmware',
     'web.src.scheduler',
     'web.src.notifications',
     'web.src.network_info',
     'web.src.router_ssh',
     'web.src.quick_scan',
-    'web.src.net_services'
-
-
-
-    'web.src.notifications'
+    'web.src.net_services',
+    'web.src.config_backup',
 ]
 
 

--- a/web/config.json
+++ b/web/config.json
@@ -1,18 +1,4 @@
 {
-    "scoring_weights": {
-        "vuln_penalty": 15,
-        "port_penalty": 5,
-        "creds_penalty": 10,
-        "patch_penalty": 5,
-        "high_risk_penalty": 3,
-        "critical_vuln_penalty": 20,
-        "cvss_penalty_factor": 1
-    },
-    "high_risk_ports": [21, 22, 23, 25, 53, 139, 445, 1433, 3306, 3389, 5900],
-    "database": "smb_enum.db",
-    "cve_api_timeout": 10,
-    "shodan_api_key": "",
-    "wigle": {"username": "", "password": ""}
   "scoring_weights": {
     "vuln_penalty": 15,
     "port_penalty": 5,
@@ -22,21 +8,10 @@
     "critical_vuln_penalty": 20,
     "cvss_penalty_factor": 1
   },
-  "high_risk_ports": [
-    21,
-    22,
-    23,
-    25,
-    53,
-    139,
-    445,
-    1433,
-    3306,
-    3389,
-    5900
-  ],
+  "high_risk_ports": [21, 22, 23, 25, 53, 139, 445, 1433, 3306, 3389, 5900],
   "database": "smb_enum.db",
   "cve_api_timeout": 10,
   "shodan_api_key": "",
+  "wigle": {"username": "", "password": ""},
   "default_shodan_query": "net:192.168.1.0/24"
 }

--- a/web/src/config_backup.py
+++ b/web/src/config_backup.py
@@ -1,0 +1,46 @@
+import os
+import subprocess
+import logging
+from typing import List
+import difflib
+
+logger = logging.getLogger(__name__)
+
+
+def backup_config(ip: str, user: str, password: str, remote_path: str, dest_dir: str = "backups") -> str:
+    """Backup the router configuration via SCP.
+
+    Returns the path to the saved file on success or an empty string on failure.
+    """
+    os.makedirs(dest_dir, exist_ok=True)
+    dest_file = os.path.join(dest_dir, f"{ip.replace('.', '_')}_config.backup")
+    cmd = [
+        "sshpass", "-p", password,
+        "scp", "-o", "StrictHostKeyChecking=no",
+        f"{user}@{ip}:{remote_path}", dest_file
+    ]
+    try:
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=30)
+        logger.info("Backed up configuration from %s to %s", ip, dest_file)
+        return dest_file
+    except Exception as exc:
+        logger.error("Failed to backup configuration: %s", exc)
+        return ""
+
+
+def verify_config(baseline_path: str, config_path: str) -> List[str]:
+    """Compare a configuration file against a baseline.
+
+    Returns a list of diff lines. An empty list means the files match.
+    """
+    if not os.path.exists(baseline_path):
+        raise FileNotFoundError(f"Baseline {baseline_path} not found")
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(f"Config {config_path} not found")
+
+    with open(baseline_path, "r", encoding="utf-8") as f1, open(config_path, "r", encoding="utf-8") as f2:
+        baseline_lines = f1.readlines()
+        config_lines = f2.readlines()
+
+    diff = list(difflib.unified_diff(baseline_lines, config_lines, fromfile="baseline", tofile="current", lineterm=""))
+    return diff

--- a/web/src/main.py
+++ b/web/src/main.py
@@ -11,6 +11,8 @@ from .scanning import discover_smb_hosts, run_nmap_scan
 from .enumeration import enumerate_lan_hosts
 from .scoring import calculate_vulnerability_score, generate_remediation
 from .plugin_loader import load_plugins
+from .network_info import get_router_ip
+from .config_backup import backup_config, verify_config
 import os
 import sys
 
@@ -21,6 +23,8 @@ def display_help():
     print("""
 === SMB-Scor3 Help ===
 1) Discover and enumerate SMB hosts: Scan a network for SMB services and assess vulnerabilities.
+3) Backup router configuration via SSH and SCP.
+4) Verify configuration against a baseline file.
 0) Exit: Quit the tool.
 
 Tips:
@@ -48,6 +52,8 @@ def main():
         print("\n=== SMB-Scor3 MAIN MENU ===")
         print("1) Discover and enumerate SMB hosts")
         print("2) Help")
+        print("3) Backup router configuration")
+        print("4) Verify configuration against baseline")
         print("0) Exit")
         choice = input("Select an option: ").strip()
 
@@ -93,6 +99,27 @@ def main():
                 logger.info("Operation cancelled by user.")
             except Exception as e:
                 logger.error(f"An error occurred: {e}")
+        elif choice == '3':
+            ip = input("Router IP [auto-detect]: ").strip() or get_router_ip()
+            if not ip:
+                print("Router IP not found.")
+                continue
+            user = input("SSH username [admin]: ").strip() or 'admin'
+            password = input("SSH password: ").strip()
+            remote = input("Remote config path [/etc/config.cfg]: ").strip() or '/etc/config.cfg'
+            dest = input("Destination directory [backups]: ").strip() or 'backups'
+            backup_config(ip, user, password, remote, dest)
+        elif choice == '4':
+            baseline = input("Baseline config file: ").strip()
+            current = input("Config file to verify: ").strip()
+            try:
+                diff = verify_config(baseline, current)
+                if not diff:
+                    print("Configuration matches baseline.")
+                else:
+                    print('\n'.join(diff))
+            except Exception as e:
+                logger.error(f"Verification failed: {e}")
         else:
             print("Invalid option. Please try again.")
 

--- a/web/src/plugins/shodan_import.py
+++ b/web/src/plugins/shodan_import.py
@@ -1,14 +1,4 @@
-"""Plugin to import results from Shodan."""
-from ..integrations.shodan import ShodanClient
-
-NAME = "ShodanImport"
-
-client = ShodanClient()
-
-def register():
-    return {"message": "Shodan plugin loaded", "api_key_set": bool(client.api_key)}
-  """Plugin to import scan results from Shodan."""
-
+"""Plugin to import scan results from Shodan."""
 from ..integrations import shodan_client
 from ..config import config
 
@@ -22,3 +12,4 @@ def register():
     query = config.get("default_shodan_query", "net:192.168.1.0/24")
     results = shodan_client.shodan_search(query, api_key)
     return {"count": len(results), "sample": results[:5]}
+


### PR DESCRIPTION
## Summary
- add new `config_backup` module for SSH-based config backup and baseline verification
- integrate backup & verify options into CLI main menu
- import new module in unit tests
- prune duplicates in `FEATURE_PROPOSAL.md` and include backup feature

## Testing
- `./runtests.sh`

## Summary by Sourcery

Add a new config_backup module with SSH/SCP-based router config backup and baseline verification, wire its options into the main CLI, update tests to include the module, and clean up the feature proposal document.

New Features:
- Introduce a config_backup module for SSH/SCP-based router configuration backup and baseline verification
- Add CLI menu options to trigger configuration backup and verify operations

Documentation:
- Prune duplicate entries and add the configuration backup feature to FEATURE_PROPOSAL.md

Tests:
- Register the new config_backup module in the unit test suite