### PR TITLE
Integrate Censys plugin and start network tunnels

### DIFF
--- a/FEATURE_PROPOSAL.md
+++ b/FEATURE_PROPOSAL.md
@@ -124,3 +124,15 @@ This document outlines proposed enhancements for the RoutR_MauraDr project.
 ## 30. Network Inventory Integration
 - Import device and topology data from common network inventory systems.
 - Use imported context to enrich scan results and prioritize high-value targets.
+
+## 31. Automated Shodan & Censys Correlation
+- Fetch data from Shodan and Censys APIs and cross-reference with local scan results.
+- Highlight discrepancies or newly discovered services.
+
+## 32. Live Tunnel Management
+- Display status of running netcat and ngrok tunnels in the GUI.
+- Provide buttons to start/stop tunnels on demand.
+
+## 33. Export Scheduler
+- Allow users to schedule automatic exports of scan summaries to JSON or CSV.
+- Useful for offline review or archiving results.

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -7,6 +7,7 @@ MODULES = [
     'web.src.integrations.shodan',
     'web.src.integrations.wigle',
     'web.src.integrations.shodan_client',
+    'web.src.integrations.censys_client',
     'web.src.firmware',
     'web.src.scheduler',
     'web.src.notifications',

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -5,7 +5,7 @@ class TestPluginLoader(unittest.TestCase):
     def test_loads_plugins(self):
         plugins = load_plugins()
         names = [p.name.lower() for p in plugins]
-        for expected in ['example', 'shodanimport', 'wiglelookup']:
+        for expected in ['example', 'shodanimport', 'wiglelookup', 'censysimport']:
             self.assertIn(expected, names)
         names = [p.name for p in plugins]
         self.assertIn('example', [n.lower() for n in names])

--- a/web/config.json
+++ b/web/config.json
@@ -13,5 +13,7 @@
   "cve_api_timeout": 10,
   "shodan_api_key": "",
   "wigle": {"username": "", "password": ""},
-  "default_shodan_query": "net:192.168.1.0/24"
+  "default_shodan_query": "net:192.168.1.0/24",
+  "censys": {"id": "", "secret": ""},
+  "default_censys_query": "services.service_name:HTTP"
 }

--- a/web/src/integrations/censys_client.py
+++ b/web/src/integrations/censys_client.py
@@ -1,0 +1,51 @@
+import logging
+from typing import Optional
+
+try:
+    import requests
+except ImportError:
+    requests = None
+
+from ..config import config
+
+CENSYS_BASE_URL = "https://search.censys.io/api"
+
+logger = logging.getLogger(__name__)
+
+
+class CensysClient:
+    """Minimal Censys API client."""
+
+    def __init__(self, api_id: Optional[str] = None, api_secret: Optional[str] = None) -> None:
+        creds = config.get("censys", {})
+        self.api_id = api_id or creds.get("id")
+        self.api_secret = api_secret or creds.get("secret")
+        if requests:
+            self.session = requests.Session()
+            if self.api_id and self.api_secret:
+                self.session.auth = (self.api_id, self.api_secret)
+            else:
+                logger.warning("Censys credentials not configured")
+        else:
+            self.session = None
+            logger.warning("requests module not available, CensysClient disabled")
+
+    def _request(self, endpoint: str, **params):
+        if not requests or not self.session:
+            logger.warning("requests module not available for CensysClient requests")
+            return None
+        try:
+            resp = self.session.get(f"{CENSYS_BASE_URL}{endpoint}", params=params, timeout=10)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:
+            logger.error("Censys request failed: %s", exc)
+            return None
+
+    def search_hosts(self, query: str):
+        """Search hosts using the Censys search API."""
+        return self._request("/v1/search/ipv4", q=query)
+
+    def view_host(self, ip: str):
+        """Retrieve details about a single host."""
+        return self._request(f"/v1/view/ipv4/{ip}")

--- a/web/src/main.py
+++ b/web/src/main.py
@@ -9,6 +9,11 @@ from .utils import (
 )
 from .scanning import discover_smb_hosts, run_nmap_scan
 from .enumeration import enumerate_lan_hosts
+from .net_services import (
+    start_netcat_listener,
+    start_ngrok_tcp,
+    start_ngrok_http,
+)
 from .scoring import calculate_vulnerability_score, generate_remediation
 from .plugin_loader import load_plugins
 from .network_info import get_router_ip
@@ -48,6 +53,11 @@ def main():
         except Exception as e:
             logger.error(f"Failed to load plugin {plugin.name}: {e}")
 
+    # Start tunneling services
+    netcat_proc = start_netcat_listener()
+    ngrok_tcp_proc = start_ngrok_tcp()
+    ngrok_http_proc = start_ngrok_http()
+
     while True:
         print("\n=== SMB-Scor3 MAIN MENU ===")
         print("1) Discover and enumerate SMB hosts")
@@ -59,6 +69,9 @@ def main():
 
         if choice == '0':
             logger.info("Exiting SMB-Scor3.")
+            for proc in (netcat_proc, ngrok_tcp_proc, ngrok_http_proc):
+                if proc:
+                    proc.terminate()
             break
         elif choice == '2':
             display_help()

--- a/web/src/plugins/censys_import.py
+++ b/web/src/plugins/censys_import.py
@@ -1,0 +1,13 @@
+"""Plugin to import scan results from Censys."""
+from ..integrations.censys_client import CensysClient
+from ..config import config
+
+NAME = "CensysImport"
+
+client = CensysClient()
+
+def register():
+    query = config.get("default_censys_query", "services.service_name:HTTP")
+    results = client.search_hosts(query)
+    count = len(results.get('results', [])) if isinstance(results, dict) else 0
+    return {"count": count, "sample": results.get('results', [])[:5] if isinstance(results, dict) else []}


### PR DESCRIPTION
## Summary
- add Censys API client and plugin
- start netcat and ngrok tunnels in main application
- extend config for Censys credentials and query
- update plugin loader tests for new plugin
- update module import tests
- expand feature proposal with new ideas

## Testing
- `./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e33945fb0832baf76dfd8fad88de4

## Summary by Sourcery

Introduce Censys API support and automatic network tunneling, and update related tests and documentation

New Features:
- Integrate Censys API client and add CensysImport plugin to fetch and sample host data
- Automatically start netcat and ngrok TCP/HTTP tunnels on application startup with graceful termination on exit

Enhancements:
- Extend plugin loader and module import tests to include the new Censys integration

Documentation:
- Expand feature proposal with automated Shodan & Censys correlation, live tunnel management, and export scheduler ideas

Tests:
- Update test_plugin_loader and test_new_modules to cover the new Censys client and plugin