### PR TITLE
Add financial modules and update documentation

### DIFF
--- a/FEATURE_ADDITIONS.md
+++ b/FEATURE_ADDITIONS.md
@@ -8,3 +8,11 @@ The following ideas could further extend RoutR_MauraDr:
    - Allow administrators to configure automatic pruning of old scan data.
 3. **Virtualization Platform Integration**
    - Connect to common hypervisor APIs to enumerate guest networks and assets.
+4. **Real-Time Market Data**
+   - Stream WebSocket updates from exchanges to the dashboard and macOS app.
+5. **Historical Backtesting**
+   - Provide a module to simulate strategies against prior market conditions.
+6. **Portfolio Tracking**
+   - Record user holdings and calculate profit and loss metrics.
+7. **iCloud Sync & Auto-Update**
+   - Keep settings synchronized and notify about new releases.

--- a/FEATURE_PROPOSAL.md
+++ b/FEATURE_PROPOSAL.md
@@ -136,3 +136,30 @@ This document outlines proposed enhancements for the RoutR_MauraDr project.
 ## 33. Export Scheduler
 - Allow users to schedule automatic exports of scan summaries to JSON or CSV.
 - Useful for offline review or archiving results.
+
+## 34. Machine Learning Anomaly Detection
+- Apply ML techniques to identify unusual network behavior over time.
+
+## 35. Multi-Exchange Market Data Streaming
+- Integrate real-time WebSocket feeds from cryptocurrency exchanges.
+
+## 36. Historical Backtesting Engine
+- Simulate detection or trading strategies against archived data sets.
+
+## 37. Portfolio Tracking Dashboard
+- Track asset holdings and PnL alongside vulnerability metrics.
+
+## 38. iCloud Configuration Sync
+- Synchronize user preferences across macOS devices via iCloud.
+
+## 39. Auto Update Notifier
+- Check for new releases of the companion tools and prompt users to update.
+
+## 40. Virtualization Guest Enumeration
+- Query common hypervisors to include virtual machines in scan scopes.
+
+## 41. Data Retention Policies
+- Provide configurable pruning of old scan artifacts.
+
+## 42. Browser Quick Scan Extension
+- Launch quick scans directly from a browser toolbar button.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,14 @@ See `FEATURE_PROPOSAL.md` for a detailed roadmap of these planned improvements.
   - Scan container images for vulnerabilities and risky configurations.
 - **Network Inventory Integration**
   - Import external device data to enrich scan results.
+- **Real-Time Market Data Streaming**
+  - Display exchange data live via WebSockets on the dashboard.
+- **Historical Backtesting Engine**
+  - Replay saved data sets to evaluate scanning or trading strategies.
+- **Portfolio Tracking**
+  - Monitor holdings and profit/loss alongside scan insights.
+- **iCloud Sync & Auto Update**
+  - Sync preferences across macOS devices and notify on new releases.
 
 
 

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -32,6 +32,15 @@ MODULES = [
     'web.src.ipv6_support',
     'web.src.plugin_marketplace',
     'web.src.mobile_companion',
+    # Modules added for financial tooling and management
+    'web.src.market_ws',
+    'web.src.backtesting',
+    'web.src.portfolio',
+    'web.src.icloud_sync',
+    'web.src.auto_update',
+    'web.src.data_retention',
+    'web.src.virtualization',
+    'web.src.browser_quick_scan',
 
 ]
 

--- a/web/src/auto_update.py
+++ b/web/src/auto_update.py
@@ -1,0 +1,20 @@
+"""Check for updates to the companion app."""
+import json
+import logging
+from urllib.request import urlopen
+
+logger = logging.getLogger(__name__)
+
+UPDATE_URL = "https://example.com/app/version.json"
+
+
+def check_for_update(current_version: str) -> bool:
+    """Return True if a newer version is available."""
+    try:
+        with urlopen(UPDATE_URL, timeout=5) as resp:
+            data = json.load(resp)
+    except Exception as exc:  # pragma: no cover - network
+        logger.warning("Update check failed: %s", exc)
+        return False
+    latest = data.get("version")
+    return latest is not None and latest != current_version

--- a/web/src/backtesting.py
+++ b/web/src/backtesting.py
@@ -1,0 +1,22 @@
+"""Simple historical data backtesting utilities."""
+import pandas as pd
+from typing import Callable, List
+
+
+def load_prices(csv_path: str) -> pd.DataFrame:
+    """Load historical price data from CSV."""
+    return pd.read_csv(csv_path, parse_dates=['date'])
+
+
+def run_backtest(prices: pd.DataFrame, strategy: Callable[[pd.DataFrame], List[int]]) -> float:
+    """Run a naive backtest given price data and a strategy callback.
+
+    The strategy should return a list of indexes representing buy signals.
+    This placeholder returns cumulative returns for demonstration.
+    """
+    buy_points = strategy(prices)
+    if not buy_points:
+        return 0.0
+    pct_change = prices['close'].pct_change().fillna(0)
+    returns = pct_change.iloc[buy_points].sum()
+    return float(returns)

--- a/web/src/browser_quick_scan.py
+++ b/web/src/browser_quick_scan.py
@@ -1,0 +1,12 @@
+"""Endpoint to trigger quick scans from the browser."""
+from flask import Blueprint, jsonify, request
+from .quick_scan import quick_port_scan
+
+bp = Blueprint('browser_quick_scan', __name__)
+
+
+@bp.route('/quick-scan')
+def quick_scan_endpoint():  # pragma: no cover - simple wrapper
+    target = request.args.get('target', '192.168.1.1')
+    result = quick_port_scan(target)
+    return jsonify(result)

--- a/web/src/data_retention.py
+++ b/web/src/data_retention.py
@@ -1,0 +1,20 @@
+"""Automatic pruning of old scan data."""
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def prune_old_scans(results_dir: Path, days: int) -> int:
+    """Delete scan files older than the given number of days."""
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    removed = 0
+    for path in results_dir.glob('*.json'):
+        if datetime.utcfromtimestamp(path.stat().st_mtime) < cutoff:
+            try:
+                path.unlink()
+                removed += 1
+            except Exception:
+                logger.warning("Failed to remove %s", path)
+    return removed

--- a/web/src/icloud_sync.py
+++ b/web/src/icloud_sync.py
@@ -1,0 +1,11 @@
+"""Placeholder iCloud synchronization utilities."""
+import logging
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+
+def sync_settings(data: Dict) -> None:
+    """Simulate syncing settings to iCloud."""
+    logger.info("Syncing %d settings to iCloud", len(data))
+    # Actual iCloud integration would go here

--- a/web/src/market_ws.py
+++ b/web/src/market_ws.py
@@ -1,0 +1,38 @@
+"""Real-time market data via WebSocket connections."""
+import json
+import logging
+import threading
+from typing import Callable, Optional
+
+try:
+    import websocket  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    websocket = None
+
+logger = logging.getLogger(__name__)
+
+
+class MarketWebSocket:
+    """Connect to an exchange WebSocket and stream updates."""
+
+    def __init__(self, url: str, callback: Callable[[dict], None]) -> None:
+        self.url = url
+        self.callback = callback
+        self._ws: Optional["websocket.WebSocketApp"] = None
+
+    def connect(self) -> None:
+        """Start the WebSocket connection in a background thread."""
+        if not websocket:
+            logger.warning("websocket-client not available")
+            return
+        self._ws = websocket.WebSocketApp(self.url, on_message=self._on_message)
+        thread = threading.Thread(target=self._ws.run_forever, daemon=True)
+        thread.start()
+
+    def _on_message(self, ws: object, message: str) -> None:  # pragma: no cover - callback
+        try:
+            data = json.loads(message)
+        except Exception:
+            logger.debug("Non-JSON message received")
+            return
+        self.callback(data)

--- a/web/src/portfolio.py
+++ b/web/src/portfolio.py
@@ -1,0 +1,27 @@
+"""Track user holdings and profit/loss."""
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class Position:
+    symbol: str
+    quantity: float
+    cost_basis: float
+
+
+@dataclass
+class Portfolio:
+    positions: Dict[str, Position] = field(default_factory=dict)
+
+    def update(self, symbol: str, quantity: float, price: float) -> None:
+        pos = self.positions.get(symbol)
+        if pos:
+            total_cost = pos.cost_basis * pos.quantity + price * quantity
+            pos.quantity += quantity
+            pos.cost_basis = total_cost / pos.quantity
+        else:
+            self.positions[symbol] = Position(symbol, quantity, price)
+
+    def value(self, prices: Dict[str, float]) -> float:
+        return sum(prices.get(sym, 0) * pos.quantity for sym, pos in self.positions.items())

--- a/web/src/quick_scan.py
+++ b/web/src/quick_scan.py
@@ -28,3 +28,12 @@ def quick_scan(target: str, out_prefix: str = "quick_scan") -> Path:
     except Exception as exc:
         logger.error("Quick scan failed: %s", exc)
         return js
+
+
+def quick_port_scan(target: str) -> dict:
+    """Convenience wrapper returning open ports as a dict."""
+    json_path = quick_scan(target)
+    try:
+        return json.loads(json_path.read_text())
+    except Exception:
+        return {"target": target, "open_ports": []}

--- a/web/src/virtualization.py
+++ b/web/src/virtualization.py
@@ -1,0 +1,23 @@
+"""Interact with common hypervisor APIs."""
+import logging
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+
+class Hypervisor:
+    def list_guests(self) -> List[str]:  # pragma: no cover - placeholder
+        raise NotImplementedError
+
+
+class LibvirtHypervisor(Hypervisor):
+    def list_guests(self) -> List[str]:
+        try:
+            import libvirt  # type: ignore
+            conn = libvirt.open(None)
+            guests = [dom.name() for dom in conn.listAllDomains()]
+            conn.close()
+            return guests
+        except Exception as exc:
+            logger.warning("Libvirt integration failed: %s", exc)
+            return []


### PR DESCRIPTION
## Summary
- create skeleton modules for market data, backtesting, portfolio tracking, iCloud sync and auto-update
- provide basic data retention, virtualization and browser quick-scan modules
- extend quick scan helper with `quick_port_scan`
- update README and feature docs with new enhancements
- include new modules in import tests

## Testing
- `./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e381fe254832baccb31a70eec5d3a

## Summary by Sourcery

Add skeleton modules for market data streaming, backtesting engine, portfolio tracking, iCloud sync, auto-update notifier, virtualization enumeration, data retention, and a browser quick-scan endpoint; extend quick_scan with quick_port_scan; update import tests and documentation.

New Features:
- Add skeleton modules for real-time market data streaming, historical backtesting, and portfolio tracking
- Add modules for iCloud settings synchronization and auto-update notifications
- Add modules for virtualization guest enumeration, automatic data retention pruning, and a browser quick-scan endpoint

Enhancements:
- Extend quick_scan helper with a quick_port_scan convenience function

Documentation:
- Update README and feature proposal/additions documentation with the new enhancements

Tests:
- Include all new modules in the import tests suite