### PR TITLE
Add CLI interface and proposal

### DIFF
--- a/CLI_GUI_FEATURE_PROPOSAL.md
+++ b/CLI_GUI_FEATURE_PROPOSAL.md
@@ -1,0 +1,15 @@
+# Additional Feature Proposals
+
+The new CLI interface opens possibilities for future enhancements. Below are some ideas that would further complement RoutR_MauraDr:
+
+1. **Interactive Plugin Manager**
+   - Allow users to list, enable and disable plugins directly from the CLI.
+   - Provide a command to install third‑party plugins from a trusted source.
+
+2. **Saved Query Library**
+   - Store frequently used Shodan, Censys and Wigle queries.
+   - Offer quick execution from the CLI or GUI via a dropdown list.
+
+3. **Batch API Operations**
+   - Accept a file of IPs or queries and perform bulk lookups across all supported APIs.
+   - Generate consolidated reports showing results from Shodan, Censys and Wigle.

--- a/README.md
+++ b/README.md
@@ -332,6 +332,13 @@ pip install -r requirements.txt
    - Runs a **quick stealth port scan** on the router (top 10 ports), trying to detect the OS.  
    - **Starts** netcat on **port 6666** and spawns **ngrok** tunnels (TCP on 6667, HTTP on 80).  
 
+### Command Line Interface
+Run individual scans or external API queries:
+```bash
+python3 -m web.src.cli scan 192.168.1.0/24 --intensity medium
+python3 -m web.src.cli shodan-search "apache"
+```
+
 ---
 
 ## **How It Works (Detailed)** <a id="how-it-works-detailed"></a>

--- a/web/src/cli.py
+++ b/web/src/cli.py
@@ -1,0 +1,89 @@
+import argparse
+import json
+from .scanning import discover_smb_hosts
+from .enumeration import enumerate_lan_hosts
+from .scoring import calculate_vulnerability_score, generate_remediation
+from .integrations.shodan import ShodanClient
+from .integrations.wigle import WigleClient
+from .integrations.censys_client import CensysClient
+
+
+def cmd_scan(args):
+    hosts = discover_smb_hosts(args.cidr)
+    host_data = enumerate_lan_hosts(hosts, args.intensity)
+    for host, data in host_data.items():
+        score, category = calculate_vulnerability_score(data)
+        print(f"{host}: score {score} ({category})")
+        remediation = generate_remediation(data)
+        for step in remediation:
+            print(f"  - {step}")
+
+
+def cmd_shodan_search(args):
+    client = ShodanClient()
+    results = client.search(args.query)
+    print(json.dumps(results, indent=2))
+
+
+def cmd_shodan_host(args):
+    client = ShodanClient()
+    info = client.host(args.ip)
+    print(json.dumps(info, indent=2))
+
+
+def cmd_wigle_ssid(args):
+    client = WigleClient()
+    results = client.search_ssid(args.ssid)
+    print(json.dumps(results, indent=2))
+
+
+def cmd_wigle_bssid(args):
+    client = WigleClient()
+    results = client.search_bssid(args.bssid)
+    print(json.dumps(results, indent=2))
+
+
+def cmd_censys_search(args):
+    client = CensysClient()
+    results = client.search_hosts(args.query)
+    print(json.dumps(results, indent=2))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="SMB-Scor3 Command Line")
+    sub = parser.add_subparsers(dest="cmd")
+
+    scan_p = sub.add_parser("scan", help="Scan network for SMB hosts")
+    scan_p.add_argument("cidr", help="Network CIDR, e.g. 192.168.1.0/24")
+    scan_p.add_argument("--intensity", default="low", choices=["low", "medium", "high"])
+    scan_p.set_defaults(func=cmd_scan)
+
+    shodan_s = sub.add_parser("shodan-search", help="Search Shodan")
+    shodan_s.add_argument("query", help="Search query")
+    shodan_s.set_defaults(func=cmd_shodan_search)
+
+    shodan_h = sub.add_parser("shodan-host", help="Lookup host on Shodan")
+    shodan_h.add_argument("ip", help="Target IP")
+    shodan_h.set_defaults(func=cmd_shodan_host)
+
+    wigle_ssid = sub.add_parser("wigle-ssid", help="Search Wigle by SSID")
+    wigle_ssid.add_argument("ssid", help="SSID to search")
+    wigle_ssid.set_defaults(func=cmd_wigle_ssid)
+
+    wigle_bssid = sub.add_parser("wigle-bssid", help="Search Wigle by BSSID")
+    wigle_bssid.add_argument("bssid", help="BSSID/MAC")
+    wigle_bssid.set_defaults(func=cmd_wigle_bssid)
+
+    censys_s = sub.add_parser("censys-search", help="Search Censys hosts")
+    censys_s.add_argument("query", help="Search query")
+    censys_s.set_defaults(func=cmd_censys_search)
+
+    args = parser.parse_args()
+    if not args.cmd:
+        parser.print_help()
+        return
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `web/src/cli.py` to provide command line access to scanning and external APIs
- document CLI usage in README
- outline additional ideas in `CLI_GUI_FEATURE_PROPOSAL.md`

## Testing
- `./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e39e5b668832b8f9eab122066c139

## Summary by Sourcery

Add a command-line interface for network scanning and external API lookups, update documentation with usage examples, and include a feature proposal for future enhancements

New Features:
- Add a command-line interface with subcommands for SMB network scanning and external API queries (Shodan, Wigle, Censys)

Documentation:
- Document CLI usage in the README
- Introduce a proposal document outlining future CLI and GUI enhancements