### PR TITLE
Implement plugin manager and query library

### DIFF
--- a/FEATURE_ADDITIONS.md
+++ b/FEATURE_ADDITIONS.md
@@ -16,3 +16,9 @@ The following ideas could further extend RoutR_MauraDr:
    - Record user holdings and calculate profit and loss metrics.
 7. **iCloud Sync & Auto-Update**
    - Keep settings synchronized and notify about new releases.
+8. **Voice-Controlled Operation**
+   - Integrate speech recognition to trigger common scans hands-free.
+9. **Cloud Configuration Backup**
+   - Optionally sync plugin settings and query libraries to cloud storage.
+10. **Interactive Network Visualization**
+   - Display discovered devices on a dynamic topology map in the GUI.

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,0 +1,16 @@
+import unittest
+from web.src import plugin_manager
+
+class TestPluginManager(unittest.TestCase):
+    def test_enable_disable(self):
+        plugins = dict(plugin_manager.list_plugins())
+        self.assertIn('example', plugins)
+        plugin_manager.disable_plugin('example')
+        plugins = dict(plugin_manager.list_plugins())
+        self.assertFalse(plugins['example'])
+        plugin_manager.enable_plugin('example')
+        plugins = dict(plugin_manager.list_plugins())
+        self.assertTrue(plugins['example'])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_query_library.py
+++ b/tests/test_query_library.py
@@ -1,0 +1,13 @@
+import unittest
+from web.src import query_library
+
+class TestQueryLibrary(unittest.TestCase):
+    def test_save_and_get(self):
+        query_library.save_query('shodan', 'unittest', 'testquery')
+        q = query_library.get_query('shodan', 'unittest')
+        self.assertEqual(q, 'testquery')
+        queries = query_library.list_queries('shodan')
+        self.assertIn('unittest', queries)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/web/data/queries.json
+++ b/web/data/queries.json
@@ -1,0 +1,7 @@
+{
+  "shodan": {
+    "unittest": "testquery"
+  },
+  "censys": {},
+  "wigle": {}
+}

--- a/web/src/batch_api.py
+++ b/web/src/batch_api.py
@@ -1,0 +1,44 @@
+import json
+from pathlib import Path
+from typing import List, Dict
+
+from .integrations.shodan_client import shodan_search, shodan_host
+from .integrations.censys_client import CensysClient
+from .integrations.wigle import WigleClient
+from .utils import validate_ip
+
+censys_client = CensysClient()
+wigle_client = WigleClient()
+
+
+def run_batch(file_path: str) -> List[Dict[str, object]]:
+    """Perform batch lookups across Shodan, Censys and Wigle."""
+    results = []
+    lines = Path(file_path).read_text().splitlines()
+    api_key = ''
+    try:
+        from .config import config
+        api_key = config.get('shodan_api_key', '')
+    except Exception:
+        pass
+    for line in lines:
+        item = line.strip()
+        if not item:
+            continue
+        entry = {'input': item}
+        if validate_ip(item):
+            entry['shodan'] = shodan_host(item, api_key) if api_key else None
+            entry['censys'] = censys_client.view_host(item)
+            entry['wigle'] = wigle_client.search_bssid(item)
+        else:
+            entry['shodan'] = shodan_search(item, api_key) if api_key else []
+            entry['censys'] = censys_client.search_hosts(item)
+            entry['wigle'] = wigle_client.search_ssid(item)
+        results.append(entry)
+    return results
+
+
+def save_report(data: List[Dict[str, object]], output: str) -> str:
+    with open(output, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)
+    return output

--- a/web/src/cli.py
+++ b/web/src/cli.py
@@ -6,6 +6,9 @@ from .scoring import calculate_vulnerability_score, generate_remediation
 from .integrations.shodan import ShodanClient
 from .integrations.wigle import WigleClient
 from .integrations.censys_client import CensysClient
+from .plugin_manager import list_plugins as pm_list, enable_plugin, disable_plugin, install_plugin
+from .query_library import list_queries, save_query, get_query
+from .batch_api import run_batch, save_report
 
 
 def cmd_scan(args):
@@ -49,6 +52,64 @@ def cmd_censys_search(args):
     print(json.dumps(results, indent=2))
 
 
+def cmd_plugin_list(args):
+    for name, enabled in pm_list():
+        status = 'enabled' if enabled else 'disabled'
+        print(f"{name}: {status}")
+
+
+def cmd_plugin_enable(args):
+    if enable_plugin(args.name):
+        print(f"Enabled {args.name}")
+    else:
+        print(f"Plugin {args.name} not found")
+
+
+def cmd_plugin_disable(args):
+    if disable_plugin(args.name):
+        print(f"Disabled {args.name}")
+    else:
+        print(f"Plugin {args.name} was not enabled")
+
+
+def cmd_plugin_install(args):
+    if install_plugin(args.url):
+        print("Plugin installed")
+    else:
+        print("Failed to install plugin")
+
+
+def cmd_query_list(args):
+    queries = list_queries(args.service)
+    for name, q in queries.items():
+        print(f"{name}: {q}")
+
+
+def cmd_query_save(args):
+    save_query(args.service, args.name, args.query)
+    print("Query saved")
+
+
+def cmd_query_run(args):
+    query = get_query(args.service, args.name)
+    if not query:
+        print("Query not found")
+        return
+    if args.service == 'shodan':
+        cmd_shodan_search(argparse.Namespace(query=query))
+    elif args.service == 'censys':
+        cmd_censys_search(argparse.Namespace(query=query))
+    else:
+        cmd_wigle_ssid(argparse.Namespace(ssid=query))
+
+
+def cmd_batch(args):
+    data = run_batch(args.file)
+    if args.output:
+        save_report(data, args.output)
+    print(json.dumps(data, indent=2))
+
+
 def main():
     parser = argparse.ArgumentParser(description="SMB-Scor3 Command Line")
     sub = parser.add_subparsers(dest="cmd")
@@ -77,6 +138,40 @@ def main():
     censys_s = sub.add_parser("censys-search", help="Search Censys hosts")
     censys_s.add_argument("query", help="Search query")
     censys_s.set_defaults(func=cmd_censys_search)
+
+    plugin = sub.add_parser("plugin", help="Manage plugins")
+    psub = plugin.add_subparsers(dest="p_cmd")
+    p_list = psub.add_parser("list", help="List plugins")
+    p_list.set_defaults(func=cmd_plugin_list)
+    p_en = psub.add_parser("enable", help="Enable plugin")
+    p_en.add_argument("name")
+    p_en.set_defaults(func=cmd_plugin_enable)
+    p_dis = psub.add_parser("disable", help="Disable plugin")
+    p_dis.add_argument("name")
+    p_dis.set_defaults(func=cmd_plugin_disable)
+    p_ins = psub.add_parser("install", help="Install plugin from URL")
+    p_ins.add_argument("url")
+    p_ins.set_defaults(func=cmd_plugin_install)
+
+    q = sub.add_parser("query", help="Manage saved queries")
+    qsub = q.add_subparsers(dest="q_cmd")
+    q_list = qsub.add_parser("list", help="List queries")
+    q_list.add_argument("service", choices=["shodan", "censys", "wigle"])
+    q_list.set_defaults(func=cmd_query_list)
+    q_save = qsub.add_parser("save", help="Save a query")
+    q_save.add_argument("service", choices=["shodan", "censys", "wigle"])
+    q_save.add_argument("name")
+    q_save.add_argument("query")
+    q_save.set_defaults(func=cmd_query_save)
+    q_run = qsub.add_parser("run", help="Run a saved query")
+    q_run.add_argument("service", choices=["shodan", "censys", "wigle"])
+    q_run.add_argument("name")
+    q_run.set_defaults(func=cmd_query_run)
+
+    batch = sub.add_parser("batch", help="Run batch API lookups")
+    batch.add_argument("file", help="File with IPs or queries")
+    batch.add_argument("--output", help="Write results to file")
+    batch.set_defaults(func=cmd_batch)
 
     args = parser.parse_args()
     if not args.cmd:

--- a/web/src/plugin_loader.py
+++ b/web/src/plugin_loader.py
@@ -1,9 +1,11 @@
 import importlib
 import pkgutil
+import json
 from pathlib import Path
 
 # Plugins live inside the web/src/plugins directory
 PLUGIN_PATH = Path(__file__).resolve().parent / 'plugins'
+ENABLED_FILE = PLUGIN_PATH / 'enabled.json'
 
 class Plugin:
     """Simple plugin representation."""
@@ -16,12 +18,27 @@ class Plugin:
         return self.module.register() if hasattr(self.module, 'register') else None
 
 
+def _enabled_names():
+    if ENABLED_FILE.exists():
+        try:
+            with open(ENABLED_FILE, 'r', encoding='utf-8') as f:
+                return set(json.load(f))
+        except Exception:
+            return set()
+    return set()
+
+
 def load_plugins():
     """Load all plugins in the plugins directory."""
     plugins = []
     if not PLUGIN_PATH.exists():
         return plugins
-    for finder, name, ispkg in pkgutil.iter_modules([str(PLUGIN_PATH)]):
+    enabled = _enabled_names()
+    for _, name, _ in pkgutil.iter_modules([str(PLUGIN_PATH)]):
+        if name == 'enabled':
+            continue
+        if enabled and name not in enabled:
+            continue
         module = importlib.import_module(f'web.src.plugins.{name}')
         plugins.append(Plugin(module))
     return plugins

--- a/web/src/plugin_manager.py
+++ b/web/src/plugin_manager.py
@@ -1,0 +1,55 @@
+import json
+from pathlib import Path
+from typing import List, Tuple
+
+from .plugin_marketplace import install_from_zip
+
+PLUGIN_DIR = Path(__file__).resolve().parent / 'plugins'
+ENABLED_FILE = PLUGIN_DIR / 'enabled.json'
+
+
+def _load_enabled() -> List[str]:
+    if ENABLED_FILE.exists():
+        with open(ENABLED_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return []
+
+
+def _save_enabled(enabled: List[str]) -> None:
+    with open(ENABLED_FILE, 'w', encoding='utf-8') as f:
+        json.dump(enabled, f, indent=2)
+
+
+def list_plugins() -> List[Tuple[str, bool]]:
+    """Return a list of (plugin_name, enabled) tuples."""
+    enabled = set(_load_enabled())
+    plugins = []
+    for p in PLUGIN_DIR.glob('*.py'):
+        if p.name == '__init__.py' or p.stem == 'enabled':
+            continue
+        plugins.append((p.stem, p.stem in enabled))
+    return plugins
+
+
+def enable_plugin(name: str) -> bool:
+    enabled = set(_load_enabled())
+    if name not in [p.stem for p in PLUGIN_DIR.glob('*.py')]:
+        return False
+    if name not in enabled:
+        enabled.add(name)
+        _save_enabled(sorted(enabled))
+    return True
+
+
+def disable_plugin(name: str) -> bool:
+    enabled = set(_load_enabled())
+    if name in enabled:
+        enabled.remove(name)
+        _save_enabled(sorted(enabled))
+        return True
+    return False
+
+
+def install_plugin(url: str) -> bool:
+    return install_from_zip(url)
+

--- a/web/src/plugins/enabled.json
+++ b/web/src/plugins/enabled.json
@@ -1,0 +1,6 @@
+[
+  "censys_import",
+  "example",
+  "shodan_import",
+  "wigle_lookup"
+]

--- a/web/src/query_library.py
+++ b/web/src/query_library.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+from typing import Dict
+
+DATA_DIR = Path(__file__).resolve().parents[1] / 'data'
+QUERY_FILE = DATA_DIR / 'queries.json'
+
+
+def load_queries() -> Dict[str, Dict[str, str]]:
+    if QUERY_FILE.exists():
+        with open(QUERY_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return {"shodan": {}, "censys": {}, "wigle": {}}
+
+
+def save_query(service: str, name: str, query: str) -> None:
+    data = load_queries()
+    service_dict = data.setdefault(service, {})
+    service_dict[name] = query
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    with open(QUERY_FILE, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)
+
+
+def get_query(service: str, name: str) -> str:
+    data = load_queries()
+    return data.get(service, {}).get(name, '')
+
+
+def list_queries(service: str) -> Dict[str, str]:
+    data = load_queries()
+    return data.get(service, {})


### PR DESCRIPTION
## Summary
- implement plugin manager module and enable/disable logic
- load enabled plugins only
- add saved query library and batch API operations
- extend CLI with plugin, query and batch commands
- document more feature ideas
- add unit tests for new modules

## Testing
- `bash runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e3d181644832ba102fceed1f09203

## Summary by Sourcery

Implement plugin management, saved query library, and batch API processing with corresponding CLI commands, and add unit tests and documentation updates

New Features:
- Add plugin manager module to install, enable, disable, and list plugins
- Introduce query library for saving, listing, and retrieving service-specific queries
- Create batch_api module for performing and reporting batch lookups across Shodan, Censys, and Wigle
- Extend CLI with 'plugin', 'query', and 'batch' commands

Enhancements:
- Update plugin_loader to load only enabled plugins from enabled.json
- Add new feature ideas entries in FEATURE_ADDITIONS.md

Documentation:
- Expand FEATURE_ADDITIONS.md with additional feature ideas

Tests:
- Add unit tests for plugin manager enable/disable logic
- Add unit tests for query library save and retrieve operations