### PR TITLE
Implement dashboard and IPv6 CLI features

### DIFF
--- a/web/src/cli.py
+++ b/web/src/cli.py
@@ -8,7 +8,13 @@ from .integrations.wigle import WigleClient
 from .integrations.censys_client import CensysClient
 from .plugin_manager import list_plugins as pm_list, enable_plugin, disable_plugin, install_plugin
 from .query_library import list_queries, save_query, get_query
+from pathlib import Path
 from .batch_api import run_batch, save_report
+from .ipv6_support import discover_ipv6_hosts
+from .result_dashboard import ResultDashboard
+from .mobile_companion import send_summary as send_mobile_summary
+from .correlation import correlate_hosts
+from .export_scheduler import ExportScheduler
 
 
 def cmd_scan(args):
@@ -110,6 +116,53 @@ def cmd_batch(args):
     print(json.dumps(data, indent=2))
 
 
+def cmd_ipv6_scan(args):
+    hosts = discover_ipv6_hosts(args.cidr)
+    for h in hosts:
+        print(h)
+
+
+def cmd_dashboard_ports(args):
+    dash = ResultDashboard(Path(args.dir))
+    summary = dash.summarize_ports()
+    print(json.dumps(summary, indent=2))
+
+
+def cmd_mobile_send(args):
+    msg = args.message
+    if args.file:
+        try:
+            with open(args.file, 'r', encoding='utf-8') as f:
+                msg = f.read()
+        except Exception:
+            pass
+    if not send_mobile_summary(args.title, msg):
+        print('Failed to send notification')
+
+
+def cmd_correlate(args):
+    with open(args.file, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    result = correlate_hosts(data)
+    print(json.dumps(result, indent=2))
+
+
+def cmd_export_schedule(args):
+    def load():
+        try:
+            with open(args.results, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except Exception:
+            return {}
+
+    sched = ExportScheduler()
+    sched.schedule(load, interval=args.interval, csv=args.csv)
+    try:
+        sched.run()
+    except KeyboardInterrupt:
+        pass
+
+
 def main():
     parser = argparse.ArgumentParser(description="SMB-Scor3 Command Line")
     sub = parser.add_subparsers(dest="cmd")
@@ -167,6 +220,30 @@ def main():
     q_run.add_argument("service", choices=["shodan", "censys", "wigle"])
     q_run.add_argument("name")
     q_run.set_defaults(func=cmd_query_run)
+
+    ipv6_p = sub.add_parser("ipv6-scan", help="Discover IPv6 hosts")
+    ipv6_p.add_argument("cidr", help="IPv6 network range")
+    ipv6_p.set_defaults(func=cmd_ipv6_scan)
+
+    dash = sub.add_parser("dashboard", help="Summarize past results")
+    dash.add_argument("dir", help="Directory of result JSONs")
+    dash.set_defaults(func=cmd_dashboard_ports)
+
+    mobile = sub.add_parser("mobile-send", help="Send a message to mobile device")
+    mobile.add_argument("title")
+    mobile.add_argument("message")
+    mobile.add_argument("--file")
+    mobile.set_defaults(func=cmd_mobile_send)
+
+    corr = sub.add_parser("correlate", help="Correlate results with Shodan/Censys")
+    corr.add_argument("file", help="Results JSON")
+    corr.set_defaults(func=cmd_correlate)
+
+    esched = sub.add_parser("export-schedule", help="Schedule periodic exports")
+    esched.add_argument("results", help="Results JSON to export")
+    esched.add_argument("--interval", type=int, default=3600)
+    esched.add_argument("--csv", action="store_true")
+    esched.set_defaults(func=cmd_export_schedule)
 
     batch = sub.add_parser("batch", help="Run batch API lookups")
     batch.add_argument("file", help="File with IPs or queries")

--- a/web/src/network_map.py
+++ b/web/src/network_map.py
@@ -1,10 +1,12 @@
 import json
 from typing import List, Optional
+from pathlib import Path
 import tkinter as tk
 from tkinter import messagebox
 
 try:
     import networkx as nx
+    from networkx.readwrite import json_graph
 except ImportError:  # pragma: no cover - library may be missing in tests
     class _SimpleGraph:
         def __init__(self):
@@ -19,6 +21,9 @@ except ImportError:  # pragma: no cover - library may be missing in tests
 
         def nodes(self):  # mimic networkx API partially
             return self._nodes
+
+        def edges(self):
+            return list(self._edges)
 
         def has_edge(self, a, b):
             return (a, b) in self._edges or (b, a) in self._edges
@@ -36,6 +41,25 @@ except ImportError:  # pragma: no cover - library may be missing in tests
         @staticmethod
         def draw_networkx(*args, **kwargs):
             pass
+
+    def _node_link_data(g: _SimpleGraph):
+        return {
+            'nodes': [{'id': n, **attrs} for n, attrs in g.nodes().items()],
+            'links': [{'source': a, 'target': b} for a, b in g.edges()]}
+
+    def _node_link_graph(data):
+        g = _SimpleGraph()
+        for node in data.get('nodes', []):
+            nid = node.pop('id')
+            g.add_node(nid, **node)
+        for link in data.get('links', []):
+            g.add_edge(link['source'], link['target'])
+        return g
+
+    json_graph = type('json_graph', (), {
+        'node_link_data': staticmethod(_node_link_data),
+        'node_link_graph': staticmethod(_node_link_graph),
+    })
 
 try:
     from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
@@ -104,4 +128,54 @@ def show_topology(hosts: List[str], parent: tk.Toplevel, router_ip: Optional[str
         messagebox.showinfo("Host Info", summary)
 
     fig.canvas.mpl_connect("button_press_event", on_click)
+
+
+def save_topology(graph: nx.Graph, path: str) -> None:
+    """Save a graph to a JSON file for historical view mode."""
+    data = json_graph.node_link_data(graph)
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)
+
+
+def load_topology(path: str) -> nx.Graph:
+    """Load a graph from a JSON file."""
+    with open(path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    return json_graph.node_link_graph(data)
+
+
+def load_history(directory: str) -> List[nx.Graph]:
+    """Load all topology JSON files from a directory."""
+    graphs = []
+    for p in sorted(Path(directory).glob('topology_*.json')):
+        try:
+            graphs.append(load_topology(str(p)))
+        except Exception:
+            continue
+    return graphs
+
+
+def export_png(graph: nx.Graph, path: str) -> None:
+    """Export a topology graph as PNG."""
+    if not plt:
+        raise RuntimeError('matplotlib not available')
+    pos = nx.spring_layout(graph)
+    nx.draw_networkx(graph, pos)
+    plt.savefig(path)
+    plt.close()
+
+
+def export_html(graph: nx.Graph, path: str) -> None:
+    """Export topology as a minimal interactive HTML."""
+    data = json.dumps(json_graph.node_link_data(graph))
+    html = (
+        "<html><body><div id='graph'></div>"
+        "<script src='https://cdn.jsdelivr.net/npm/vis-network/standalone/umd/vis-network.min.js'></script>"
+        "<script>var data = new vis.DataSet(JSON.parse('" + data.replace("'", "\'") + "').nodes);"
+        "var edges = new vis.DataSet(JSON.parse('" + data.replace("'", "\'") + "').links);"
+        "var container=document.getElementById('graph');"
+        "new vis.Network(container,{nodes:data,edges:edges},{})</script></body></html>"
+    )
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(html)
 


### PR DESCRIPTION
## Summary
- expand topology utilities with save/load/export functions
- extend CLI with new commands for IPv6 scanning, dashboard summaries, mobile notifications, correlation and export scheduling

## Testing
- `./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e43a43000832b84d88f28e4cb86cb

## Summary by Sourcery

Implement new CLI features for IPv6 discovery, result summarization, notifications, data correlation, and export scheduling, and extend network topology utilities with persistence and export capabilities.

New Features:
- Add CLI commands for IPv6 scanning, dashboard summaries, mobile notifications, host correlation, and scheduled exports
- Extend network_map with functions to save, load, and export topology graphs (JSON, PNG, HTML) and load topology history