### PR TITLE
Add hcxdumptool wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ See `FEATURE_PROPOSAL.md` for a detailed roadmap of these planned improvements.
   - Export scan summaries to HTML and PDF and schedule email delivery.
 - **802.11 Wireless Scanning**
   - Map nearby Wi-Fi networks and optionally capture handshakes.
+- **PMKID Capture via hcxdumptool**
+  - Collect WPA hashes for offline cracking.
 - **Container Security Auditing**
   - Scan container images for vulnerabilities and risky configurations.
 - **Network Inventory Integration**

--- a/proposals.md
+++ b/proposals.md
@@ -7,3 +7,6 @@
 - Support AppImage packaging for easier Linux distribution.
 - Add GPU monitoring dashboard to visualize hashcat workload.
 - Integrate Zeek for automated pcap analysis with alerting.
+- hcxdumptool integration for PMKID collection and automated hashcat cracking.
+- Real-time security event timeline with WebSocket updates.
+- QR code generation for securely sharing captured Wi-Fi credentials.

--- a/routR/tools/wrappers.py
+++ b/routR/tools/wrappers.py
@@ -96,3 +96,10 @@ async def run_pgrok(port: int) -> Dict[str, Any]:
     if not is_available("pgrok"):
         return {"error": "pgrok missing"}
     return await _run_tool(["pgrok", "http", str(port)])
+
+
+async def run_hcxdumptool(interface: str, output: str) -> Dict[str, Any]:
+    """Capture wireless traffic using hcxdumptool."""
+    if not is_available("hcxdumptool"):
+        return {"error": "hcxdumptool missing"}
+    return await _run_tool(["hcxdumptool", "-i", interface, "-o", output, "--enable_status=1"])

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -19,3 +19,11 @@ class TestWrappers(unittest.TestCase):
 
         with mock.patch("routR.tools.wrappers.is_available", return_value=False):
             asyncio.run(run())
+
+    def test_run_hcxdumptool_missing(self):
+        async def run():
+            result = await wrappers.run_hcxdumptool("wlan0", "out.pcap")
+            self.assertIn("error", result)
+
+        with mock.patch("routR.tools.wrappers.is_available", return_value=False):
+            asyncio.run(run())

--- a/web/src/api/routes_v2.py
+++ b/web/src/api/routes_v2.py
@@ -54,6 +54,7 @@ class Health(Resource):
             "nikto",
             "sqlmap",
             "pgrok",
+            "hcxdumptool",
         ]
         status = {t: wrappers.is_available(t) for t in tools}
         return {"ready": True, "tools": status}, 200


### PR DESCRIPTION
## Summary
- support wireless PMKID capture via hcxdumptool
- update API health check
- mention PMKID capture in docs
- extend wrapper tests
- outline additional feature ideas

## Testing
- `./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e66112e40832ba061fddc87f5f57c

## Summary by Sourcery

Add support for hcxdumptool-based PMKID capture by introducing a new wrapper, updating the API health check, extending tests, and documenting the feature and related roadmap items.

New Features:
- Introduce run_hcxdumptool wrapper to capture wireless PMKID via hcxdumptool.

Enhancements:
- Include hcxdumptool in the API's tool availability health check.

Documentation:
- Document PMKID capture via hcxdumptool in README and update proposals with related feature ideas.

Tests:
- Add test for handling missing hcxdumptool availability in run_hcxdumptool.