### PR TITLE
Implement internet health monitor

### DIFF
--- a/tests/test_internet_health.py
+++ b/tests/test_internet_health.py
@@ -1,0 +1,25 @@
+import unittest
+from unittest import mock
+
+from web.src import internet_health
+
+
+class TestInternetHealth(unittest.TestCase):
+    def test_check_connectivity(self):
+        with mock.patch("subprocess.run") as run:
+            run.return_value.returncode = 0
+            self.assertTrue(internet_health.check_connectivity())
+            run.assert_called_once()
+
+    def test_monitor_reboot(self):
+        with mock.patch("web.src.internet_health.check_connectivity", side_effect=[False, False, True]):
+            with mock.patch("web.src.internet_health.reboot_router") as reboot, \
+                 mock.patch("web.src.internet_health.send_pushbullet") as notify, \
+                 mock.patch("time.sleep"):
+                internet_health.monitor(router_ip="1.1.1.1", interval=0, threshold=2, iterations=3)
+                reboot.assert_called_once_with("1.1.1.1")
+                notify.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/src/cli.py
+++ b/web/src/cli.py
@@ -17,6 +17,7 @@ from .correlation import correlate_hosts
 from .export_scheduler import ExportScheduler
 from .update_db import update_database
 from .plugin_harness import run_tests as run_plugin_tests
+from .internet_health import monitor as monitor_health
 from .scan_profiles import (
     add_profile,
     remove_profile,
@@ -171,6 +172,10 @@ def cmd_export_schedule(args):
         pass
 
 
+def cmd_monitor(args):
+    monitor_health(args.router_ip, args.interval, args.threshold)
+
+
 def cmd_update_db(args):
     if update_database(args.url):
         print("Database updated")
@@ -296,6 +301,12 @@ def main():
     upd = sub.add_parser("update-db", help="Update vulnerability database")
     upd.add_argument("--url", default=None, help="Source URL")
     upd.set_defaults(func=cmd_update_db)
+
+    mon = sub.add_parser("health-monitor", help="Monitor internet connectivity")
+    mon.add_argument("--router-ip", default=None, help="Router IP")
+    mon.add_argument("--interval", type=int, default=60)
+    mon.add_argument("--threshold", type=int, default=3)
+    mon.set_defaults(func=cmd_monitor)
 
     ptest = psub.add_parser("test", help="Validate plugin files")
     ptest.add_argument("paths", nargs="+", help="Plugin paths")

--- a/web/src/internet_health.py
+++ b/web/src/internet_health.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+"""Simple internet connectivity monitor with auto-reboot."""
+
+import subprocess
+import time
+import logging
+from typing import Optional
+
+from .notifications import send_pushbullet
+from .network_info import get_router_ip
+from .router_ssh import reboot_router
+
+logger = logging.getLogger(__name__)
+
+
+def check_connectivity(host: str = "8.8.8.8") -> bool:
+    """Return True if the host is reachable via ping."""
+    try:
+        result = subprocess.run(
+            ["ping", "-c", "1", "-W", "2", host],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return result.returncode == 0
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Connectivity check failed: %s", exc)
+        return False
+
+
+def monitor(
+    router_ip: Optional[str] = None,
+    interval: int = 60,
+    threshold: int = 3,
+    iterations: Optional[int] = None,
+) -> None:
+    """Monitor connectivity and reboot router on repeated failure."""
+    router_ip = router_ip or get_router_ip()
+    fails = 0
+    count = 0
+    while iterations is None or count < iterations:
+        if check_connectivity():
+            fails = 0
+        else:
+            fails += 1
+            logger.warning("Connectivity check failed (%s/%s)", fails, threshold)
+            if fails >= threshold:
+                if router_ip:
+                    reboot_router(router_ip)
+                send_pushbullet(
+                    "RoutR: Connectivity Issue",
+                    "Internet unreachable, reboot triggered",
+                )
+                fails = 0
+        count += 1
+        time.sleep(interval)

--- a/web/src/router_ssh.py
+++ b/web/src/router_ssh.py
@@ -29,3 +29,33 @@ def attempt_default_credentials(ip: str, creds: List[Tuple[str, str]] = DEFAULT_
         except Exception as exc:
             logger.debug("SSH attempt failed: %s", exc)
     return "", ""
+
+
+def reboot_router(ip: str, user: str | None = None, password: str | None = None) -> bool:
+    """Reboot the router via SSH.
+
+    If ``user`` and ``password`` are not provided, ``attempt_default_credentials``
+    will be used to discover working credentials.
+    """
+    if not user or not password:
+        user, password = attempt_default_credentials(ip)
+        if not user:
+            logger.error("No valid SSH credentials found for %s", ip)
+            return False
+    cmd = [
+        "sshpass",
+        "-p",
+        password,
+        "ssh",
+        "-o",
+        "StrictHostKeyChecking=no",
+        f"{user}@{ip}",
+        "reboot",
+    ]
+    try:
+        subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=10, check=True)
+        logger.info("Reboot command sent to %s", ip)
+        return True
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Failed to reboot router %s: %s", ip, exc)
+        return False


### PR DESCRIPTION
## Summary
- add `reboot_router` helper for issuing a reboot command over SSH
- implement `internet_health` monitor with automatic reboot and notifications
- expose new `health-monitor` command in CLI
- test connectivity checks and monitor logic

## Testing
- `./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e6a41cdb4832bbfa652998a44d575

## Summary by Sourcery

Implement an internet connectivity monitor that periodically pings a host, reboots the router after consecutive failures, and sends notifications, exposed via a CLI command.

New Features:
- Add reboot_router helper for SSH-based router reboot
- Implement internet health monitor with automatic reboots and notifications
- Expose new health-monitor command in the CLI

Tests:
- Add unit tests for connectivity checks and monitor logic