### PR TITLE
Fix runner stdin loading and add tests

### DIFF
--- a/EXTRA_FEATURE_PROPOSAL.md
+++ b/EXTRA_FEATURE_PROPOSAL.md
@@ -1,0 +1,20 @@
+# Additional Feature Proposal
+
+The following ideas could further enhance RoutR_MauraDr and complement the existing roadmap:
+
+1. **Slack/Discord Notifications**
+   - Send scan completion alerts and important events to a team chat.
+   - Allow configuration of webhooks through the CLI and web interface.
+
+2. **Containerized Execution**
+   - Offer Docker images for isolated tool runs.
+   - Provide options to spawn containers automatically when executing scans to avoid local dependencies.
+
+3. **Dynamic Target Discovery**
+   - Integrate ARP and mDNS probes to automatically expand target lists before running tools.
+   - Present discovered hosts in the dashboard for quick selection.
+
+4. **Custom Report Templates**
+   - Allow users to define Jinja2 templates for reports.
+   - Support exporting to HTML or PDF with branding and custom sections.
+

--- a/routR/tools/runner.py
+++ b/routR/tools/runner.py
@@ -8,6 +8,7 @@ import json
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+import sys
 
 from . import wrappers
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,19 @@
+import io
+import json
+import unittest
+from unittest import mock
+
+from routR.tools.runner import load_jobs
+
+
+class TestRunner(unittest.TestCase):
+    def test_load_jobs_from_stdin(self):
+        job_data = {"jobs": [{"tool": "masscan", "args": ["127.0.0.1"]}]}
+        buf = io.StringIO(json.dumps(job_data))
+        with mock.patch("sys.stdin", buf):
+            jobs = load_jobs(None)
+        self.assertEqual(jobs, job_data["jobs"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- import `sys` in runner
- use stdin in `load_jobs` when no path is given
- add tests for job loading from stdin
- propose additional features for RoutR

## Testing
- `bash runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e7607296c832b86792016a5daa7ea

## Summary by Sourcery

Enable runner to import from stdin when no input path is specified and add corresponding tests, along with a proposal document for future features.

Enhancements:
- Support loading job definitions from stdin when no file path is provided

Documentation:
- Add an additional feature proposal document outlining future enhancements

Tests:
- Add unit test for loading jobs from stdin