### PR TITLE
Add report directory arg to runner

### DIFF
--- a/routR/tools/runner.py
+++ b/routR/tools/runner.py
@@ -43,7 +43,17 @@ def load_jobs(path: Optional[Path]) -> List[Dict[str, Any]]:
 def main(argv: Optional[List[str]] = None) -> None:
     parser = argparse.ArgumentParser(description="RoutR tool runner")
     parser.add_argument("--job-file", type=Path, help="JSON job description")
+    parser.add_argument(
+        "--report-dir",
+        type=Path,
+        default=Path("reports"),
+        help="directory to store generated reports",
+    )
     args = parser.parse_args(argv)
+
+    global REPORT_DIR
+    REPORT_DIR = args.report_dir
+    REPORT_DIR.mkdir(exist_ok=True)
 
     jobs = load_jobs(args.job_file)
     job_id = str(uuid.uuid4())

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2,8 +2,10 @@ import io
 import json
 import unittest
 from unittest import mock
+from tempfile import TemporaryDirectory
+from pathlib import Path
 
-from routR.tools.runner import load_jobs
+from routR.tools import runner
 
 
 class TestRunner(unittest.TestCase):
@@ -11,9 +13,22 @@ class TestRunner(unittest.TestCase):
         job_data = {"jobs": [{"tool": "masscan", "args": ["127.0.0.1"]}]}
         buf = io.StringIO(json.dumps(job_data))
         with mock.patch("sys.stdin", buf):
-            jobs = load_jobs(None)
+            jobs = runner.load_jobs(None)
         self.assertEqual(jobs, job_data["jobs"])
+
+    def test_main_report_dir(self):
+        job_data = {"jobs": []}
+        with TemporaryDirectory() as tmpdir:
+            job_file = Path(tmpdir) / "jobs.json"
+            job_file.write_text(json.dumps(job_data))
+            out = io.StringIO()
+            with mock.patch("sys.stdout", out):
+                runner.main(["--job-file", str(job_file), "--report-dir", tmpdir])
+            job_id = out.getvalue().strip()
+            report_path = Path(tmpdir) / f"{job_id}.json"
+            self.assertTrue(report_path.exists())
 
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
## Summary
- support `--report-dir` in `routR/tools/runner.py`
- write reports to the given directory
- test that reports are generated in the location provided

## Testing
- `./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685f56889458832b84f28ca192a68a77

## Summary by Sourcery

Allow configuring the output directory for generated reports via a new command-line flag, ensure the directory is created, and add tests to verify report placement.

New Features:
- Add --report-dir argument to specify where reports are written

Enhancements:
- Create the report directory if it does not exist before running jobs

Tests:
- Add test verifying that reports are generated in the specified directory
- Update test imports to use runner.load_jobs instead of direct function import