### PR TITLE
Improve load_jobs and add test

### DIFF
--- a/FURTHER_FEATURES.md
+++ b/FURTHER_FEATURES.md
@@ -1,0 +1,12 @@
+# Proposed Future Enhancements
+
+The following ideas would further complement RoutR_MauraDr and extend its capabilities.
+
+- **Certificate Health Checks**
+  - Scan HTTPS services discovered during enumeration and report on certificate expiry or misconfiguration.
+- **Interactive Topology Map**
+  - Provide a zoomable D3.js visualization of discovered hosts and their relationships in the web UI.
+- **Configuration Baseline Alerts**
+  - Compare router settings against recommended baselines and flag risky defaults like open management ports.
+- **MITRE ATT&CK Correlation**
+  - Map findings to common ATT&CK techniques to help prioritize remediation tasks.

--- a/routR/tools/runner.py
+++ b/routR/tools/runner.py
@@ -36,7 +36,23 @@ async def run_jobs(jobs: List[Dict[str, Any]], job_id: str) -> Dict[str, Any]:
 
 
 def load_jobs(path: Optional[Path]) -> List[Dict[str, Any]]:
-    data = json.load(path.open()) if path else json.load(sys.stdin)
+    """Load job definitions from ``path`` or ``stdin``.
+
+    If ``path`` is provided, the file is opened in a context manager.  A missing
+    file results in an empty list being returned.  Invalid JSON results in a
+    ``ValueError`` with a clear message.
+    """
+
+    try:
+        if path:
+            with path.open() as f:
+                data = json.load(f)
+        else:
+            data = json.load(sys.stdin)
+    except FileNotFoundError:
+        return []
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in job file: {path}") from exc
     return data.get("jobs", [])
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,6 +1,8 @@
 import io
 import json
 import unittest
+import tempfile
+from pathlib import Path
 from unittest import mock
 
 from routR.tools.runner import load_jobs
@@ -12,6 +14,14 @@ class TestRunner(unittest.TestCase):
         buf = io.StringIO(json.dumps(job_data))
         with mock.patch("sys.stdin", buf):
             jobs = load_jobs(None)
+        self.assertEqual(jobs, job_data["jobs"])
+
+    def test_load_jobs_from_file(self):
+        job_data = {"jobs": [{"tool": "masscan", "args": ["127.0.0.1"]}]}
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "jobs.json"
+            p.write_text(json.dumps(job_data))
+            jobs = load_jobs(p)
         self.assertEqual(jobs, job_data["jobs"])
 
 


### PR DESCRIPTION
## Summary
- handle file access errors in `load_jobs`
- add tests for loading job files
- document further feature ideas

## Testing
- `./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685f568fbc98832b94deb7d09f441872

## Summary by Sourcery

Improve load_jobs to handle missing or malformed job files gracefully, add corresponding unit tests for file-based loading, and introduce a new document listing proposed future enhancements.

Bug Fixes:
- Return an empty job list when the specified job file is not found
- Provide a clear ValueError message when job file contains invalid JSON

Enhancements:
- Enhance load_jobs with file context management and docstring for better error handling

Documentation:
- Add FURTHER_FEATURES.md to outline proposed future enhancements

Tests:
- Add unit test for loading jobs from a file