### PR TITLE
Improve topology display error handling

### DIFF
--- a/COMPLEMENTARY_FEATURES.md
+++ b/COMPLEMENTARY_FEATURES.md
@@ -1,0 +1,12 @@
+# Complementary Feature Proposals
+
+These ideas aim to build upon the existing functionality of RoutR_MauraDr and improve overall usability.
+
+- **Interactive Report Annotation**
+  - Allow users to add notes or tags directly on exported reports.
+- **Cloud Sync for Scan History**
+  - Provide optional integration with cloud storage services to keep historical scan data backed up and accessible.
+- **Configurable Alert Thresholds**
+  - Let administrators set custom thresholds for warnings and alerts across modules.
+- **Simple REST API**
+  - Expose core scanning and reporting features via a lightweight REST API for automation.

--- a/tests/test_network_map.py
+++ b/tests/test_network_map.py
@@ -1,4 +1,6 @@
 import unittest
+from unittest import mock
+from web.src import network_map
 from web.src.network_map import build_topology
 
 class TestNetworkMap(unittest.TestCase):
@@ -8,6 +10,11 @@ class TestNetworkMap(unittest.TestCase):
         self.assertTrue(graph.has_node('192.168.1.1'))
         self.assertTrue(graph.has_edge('192.168.1.1', '192.168.1.2'))
         self.assertTrue(graph.has_edge('192.168.1.1', '192.168.1.3'))
+
+    def test_show_topology_missing_matplotlib(self):
+        with mock.patch.object(network_map, 'plt', None):
+            with self.assertRaises(RuntimeError):
+                network_map.show_topology([], parent=None)
 
 if __name__ == '__main__':
     unittest.main()

--- a/web/src/network_map.py
+++ b/web/src/network_map.py
@@ -101,6 +101,8 @@ def build_topology(hosts: List[str], router_ip: Optional[str] = None, shodan_api
 
 def show_topology(hosts: List[str], parent: tk.Toplevel, router_ip: Optional[str] = None) -> None:
     """Display an interactive topology map in a Tk window."""
+    if not plt:
+        raise RuntimeError("matplotlib not available")
     G = build_topology(hosts, router_ip)
     fig, ax = plt.subplots(figsize=(6, 4))
     pos = nx.spring_layout(G)


### PR DESCRIPTION
## Summary
- raise `RuntimeError` when `matplotlib` is missing in `show_topology`
- test missing `matplotlib` handling
- add complementary feature proposal document

## Testing
- `./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685f700e0508832b8c2c14355ec25f77

## Summary by Sourcery

Introduce explicit error handling in show_topology when matplotlib is unavailable, add a corresponding test, and include a complementary feature proposals document.

Bug Fixes:
- Raise RuntimeError in show_topology if matplotlib is missing.

Documentation:
- Add Complementary Feature Proposals document outlining future enhancements.

Tests:
- Add unit test to verify RuntimeError is raised when matplotlib is unavailable in show_topology.