### PR TITLE
Improve certificate and baseline tests

### DIFF
--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -9,6 +9,16 @@ class TestBaseline(unittest.TestCase):
         alerts = result['1.1.1.1'].get('baseline_alerts')
         self.assertTrue(alerts)
 
+    def test_check_baseline_no_risky_ports(self):
+        host_data = {'1.1.1.1': {'open_ports': [22]}}
+        result = check_baseline(host_data, {'recommended_ports_closed': [21, 80]})
+        self.assertNotIn('baseline_alerts', result['1.1.1.1'])
+
+    def test_check_baseline_no_open_ports(self):
+        host_data = {'1.1.1.1': {'open_ports': []}}
+        result = check_baseline(host_data, {'recommended_ports_closed': [21, 80]})
+        self.assertNotIn('baseline_alerts', result['1.1.1.1'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_certificate.py
+++ b/tests/test_certificate.py
@@ -1,4 +1,7 @@
 import unittest
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
 from web.src.certificate import check_certificate
 
 
@@ -6,6 +9,51 @@ class TestCertificate(unittest.TestCase):
     def test_check_certificate_error(self):
         info = check_certificate('localhost')
         self.assertIn('error', info)
+
+    def _mock_ssl(self, cert):
+        """Helper to patch ssl context and socket with provided cert."""
+        mock_sock = MagicMock()
+        mock_sock.__enter__.return_value = mock_sock
+        mock_sock.__exit__.return_value = False
+        mock_sock.getpeercert.return_value = cert
+        mock_sock.settimeout.return_value = None
+        mock_sock.connect.return_value = None
+        mock_ctx = MagicMock()
+        mock_ctx.wrap_socket.return_value = mock_sock
+        return (
+            patch('ssl.create_default_context', return_value=mock_ctx),
+            patch('socket.socket', return_value=MagicMock()),
+        )
+
+    def test_parse_notafter_and_hostname_match(self):
+        now = datetime(2023, 1, 1)
+        expires = now + timedelta(days=5)
+        cert = {
+            'notAfter': expires.strftime('%b %d %H:%M:%S %Y GMT'),
+            'subject': ((('commonName', 'example.com'),),),
+        }
+        ssl_patch, sock_patch = self._mock_ssl(cert)
+        with ssl_patch, sock_patch, patch('web.src.certificate.datetime') as mock_dt:
+            mock_dt.strptime = datetime.strptime
+            mock_dt.utcnow.return_value = now
+            info = check_certificate('example.com')
+        self.assertEqual(info['days_left'], 5)
+        self.assertTrue(info['hostname_match'])
+        self.assertEqual(info['subject'], 'example.com')
+
+    def test_wildcard_hostname_match(self):
+        now = datetime(2023, 2, 1)
+        expires = now + timedelta(days=1)
+        cert = {
+            'notAfter': expires.strftime('%b %d %H:%M:%S %Y GMT'),
+            'subject': ((('commonName', '*.example.com'),),),
+        }
+        ssl_patch, sock_patch = self._mock_ssl(cert)
+        with ssl_patch, sock_patch, patch('web.src.certificate.datetime') as mock_dt:
+            mock_dt.strptime = datetime.strptime
+            mock_dt.utcnow.return_value = now
+            info = check_certificate('sub.example.com')
+        self.assertTrue(info['hostname_match'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- mock SSL sockets when checking certificates
- cover wildcard and notAfter parsing logic in certificate tests
- ensure no baseline alerts when ports are safe

## Testing
- `./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685f700eb180832b9e705e8e86182d76

## Summary by Sourcery

Improve test coverage for certificate checking and baseline alert logic

Enhancements:
- Add a helper to mock SSL contexts and sockets in certificate tests

Tests:
- Add tests for parsing certificate expiration dates, extracting subjects, hostname matching, and wildcard domains
- Add baseline tests to verify no alerts are generated when only safe ports are open or no ports are open