### PR TITLE
Add enumeration instructions and feature proposal

### DIFF
--- a/MORE_FEATURES_PROPOSAL.md
+++ b/MORE_FEATURES_PROPOSAL.md
@@ -1,0 +1,14 @@
+# Complementary Feature Proposal
+
+The following ideas would further enhance RoutR_MauraDr:
+
+- **Automated Certificate Renewal Suggestions**
+  - Use collected certificate data to notify administrators when a device's HTTPS certificate is close to expiry.
+- **Baseline Scoring Dashboard**
+  - Provide a simple score for each host based on how well it matches the recommended baseline configuration.
+- **Historical Topology Diff**
+  - Allow exporting multiple topology snapshots and highlight changes between scans.
+- **PDF Report Generation**
+  - Add a command line option to export scan results directly to PDF using the existing report generator.
+- **Container Fingerprinting**
+  - Detect running containers on enumerated hosts and correlate them with known vulnerabilities.

--- a/README.md
+++ b/README.md
@@ -349,6 +349,46 @@ python3 -m web.src.cli scan 192.168.1.0/24 --intensity medium
 python3 -m web.src.cli shodan-search "apache"
 ```
 
+### Enumeration with Certificate and Baseline Checks
+
+Running a scan through the CLI automatically performs HTTPS certificate
+validation and compares the results against the configuration baseline.
+To generate a full report with these checks enabled run:
+
+```bash
+python3 -m web.src.cli scan 192.168.1.0/24 --intensity high > scan_results.json
+```
+
+Each host entry in `scan_results.json` will include a `certificate` section
+describing expiry and hostname matching along with any `baseline_alerts`
+highlighting risky open management ports.
+
+### Viewing the Topology Map
+
+The Tkinter GUI provides a quick way to view the network topology. Launch it
+with:
+
+```bash
+python3 web/src/gui.py
+```
+
+After a scan finishes click **Show Map** to open an interactive D3.js view of
+the discovered hosts.
+
+To export the map directly from the CLI you can use the helper functions in
+`web.src.network_map`:
+
+```bash
+python3 - <<'EOF'
+from web.src.network_map import build_topology, export_d3_html
+hosts = ['192.168.1.2']
+graph = build_topology(hosts, router_ip='192.168.1.1')
+export_d3_html(graph, 'topology.html')
+EOF
+```
+
+Open `topology.html` in your browser to explore the network graph.
+
 ---
 
 ## **How It Works (Detailed)** <a id="how-it-works-detailed"></a>


### PR DESCRIPTION
## Summary
- explain how to run enumeration with certificate checks and baseline alerts
- document GUI and CLI options for viewing the D3.js topology map
- propose additional features in a new doc

## Testing
- `./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685f70109874832bbdfc4ea96e6b2b07

## Summary by Sourcery

Update documentation to explain new enumeration scans with certificate and baseline checks and topology map viewing/export options, and add a proposal document outlining future feature ideas.

Documentation:
- Add instructions for running CLI scans with HTTPS certificate validation and baseline alerts
- Document GUI and CLI methods for viewing and exporting the network topology map
- Introduce a new proposal file with complementary feature enhancement ideas