### PR TITLE
Add Binance execution module

### DIFF
--- a/tests/test_binance_execution.py
+++ b/tests/test_binance_execution.py
@@ -1,0 +1,63 @@
+import unittest
+from unittest import mock
+
+from web.src.trading.binance_execution import BinanceExecution
+
+
+class TestBinanceExecution(unittest.TestCase):
+    def setUp(self):
+        self.cfg_patch = mock.patch(
+            "web.src.trading.binance_execution.config",
+            {
+                "binance": {
+                    "api_key": "key",
+                    "api_secret": "secret",
+                    "live": False,
+                    "max_position": 2,
+                    "rate_limit": 0,
+                }
+            },
+        )
+        self.cfg_patch.start()
+
+    def tearDown(self):
+        self.cfg_patch.stop()
+
+    def test_paper_order(self):
+        be = BinanceExecution()
+        result = be.place_order("BTCUSDT", "BUY", 1)
+        self.assertTrue(result["paper"])
+        self.assertEqual(result["quantity"], 1)
+
+    def test_live_order(self):
+        requests_mock = mock.Mock()
+        requests_mock.post.return_value.json.return_value = {"status": "filled"}
+        requests_mock.post.return_value.raise_for_status.return_value = None
+        with mock.patch(
+            "web.src.trading.binance_execution.requests", requests_mock
+        ):
+            cfg = {
+                "binance": {
+                    "api_key": "k",
+                    "api_secret": "s",
+                    "live": True,
+                    "max_position": 5,
+                    "rate_limit": 0,
+                }
+            }
+            with mock.patch(
+                "web.src.trading.binance_execution.config", cfg
+            ):
+                be = BinanceExecution()
+                res = be.place_order("ETHUSDT", "SELL", 1.5, stop_loss=1.0)
+        requests_mock.post.assert_called_once()
+        self.assertEqual(res["status"], "filled")
+
+    def test_max_position(self):
+        be = BinanceExecution()
+        with self.assertRaises(ValueError):
+            be.place_order("BTCUSDT", "BUY", 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -41,6 +41,7 @@ MODULES = [
     'web.src.data_retention',
     'web.src.virtualization',
     'web.src.browser_quick_scan',
+    'web.src.trading.binance_execution',
 
 ]
 

--- a/web/config.json
+++ b/web/config.json
@@ -15,5 +15,12 @@
   "wigle": {"username": "", "password": ""},
   "default_shodan_query": "net:192.168.1.0/24",
   "censys": {"id": "", "secret": ""},
-  "default_censys_query": "services.service_name:HTTP"
+  "default_censys_query": "services.service_name:HTTP",
+  "binance": {
+    "api_key": "",
+    "api_secret": "",
+    "live": false,
+    "max_position": 0,
+    "rate_limit": 1
+  }
 }

--- a/web/src/trading/binance_execution.py
+++ b/web/src/trading/binance_execution.py
@@ -1,0 +1,82 @@
+"""Simple Binance order execution wrapper."""
+import logging
+import time
+from typing import Dict, Optional
+
+try:
+    import requests
+except Exception:  # pragma: no cover - optional dependency
+    requests = None
+
+from ..config import config
+
+logger = logging.getLogger(__name__)
+
+API_URL = "https://api.binance.com/api/v3/order"
+
+
+class BinanceExecution:
+    """Place orders on Binance with optional paper trading."""
+
+    def __init__(self, live: Optional[bool] = None) -> None:
+        cfg = config.get("binance", {})
+        self.live = live if live is not None else cfg.get("live", False)
+        self.api_key = cfg.get("api_key", "")
+        self.api_secret = cfg.get("api_secret", "")
+        self.max_position = float(cfg.get("max_position", 0))
+        self.rate_limit = float(cfg.get("rate_limit", 1))
+        self._last_call = 0.0
+
+    def _throttle(self) -> None:
+        wait = self.rate_limit - (time.time() - self._last_call)
+        if wait > 0:
+            time.sleep(wait)
+        self._last_call = time.time()
+
+    def place_order(
+        self,
+        symbol: str,
+        side: str,
+        quantity: float,
+        stop_loss: Optional[float] = None,
+    ) -> Dict:
+        """Place a market order or log it when paper trading."""
+        if quantity <= 0:
+            raise ValueError("quantity must be positive")
+        if self.max_position and quantity > self.max_position:
+            raise ValueError("quantity exceeds max position")
+        if stop_loss is not None and stop_loss <= 0:
+            raise ValueError("stop_loss must be positive")
+
+        if not self.live:
+            logger.info("Paper order %s %s %s", side, quantity, symbol)
+            return {
+                "symbol": symbol,
+                "side": side,
+                "quantity": quantity,
+                "paper": True,
+            }
+
+        if not requests:
+            logger.warning("requests module not available, cannot place order")
+            return {}
+
+        self._throttle()
+        headers = {"X-MBX-APIKEY": self.api_key} if self.api_key else {}
+        payload = {
+            "symbol": symbol,
+            "side": side.upper(),
+            "type": "MARKET",
+            "quantity": quantity,
+        }
+        if stop_loss:
+            payload["stopPrice"] = stop_loss
+            payload["type"] = "STOP_LOSS_MARKET"
+
+        try:
+            resp = requests.post(API_URL, headers=headers, data=payload, timeout=10)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.error("Order failed: %s", exc)
+            raise RuntimeError("order failed") from exc


### PR DESCRIPTION
## Summary
- add trading binance execution module with paper and live modes
- support API configuration and safety checks
- test binance execution logic with mocks
- add newline to JSON files to keep formatting

## Testing
- `bash runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685f7ab2dc9c832b826dfa32e746355d

## Summary by Sourcery

Introduce a Binance execution module for placing market and stop-loss orders with configurable paper and live modes, enforce safety checks and rate limiting, and update tests and config accordingly.

New Features:
- Add BinanceExecution class to place orders on Binance with market and stop-loss support
- Support paper trading and live trading modes via user-configured API settings

Enhancements:
- Enforce rate limiting and validate order parameters against max position and positive values

Tests:
- Add unit tests for BinanceExecution covering paper orders, live orders with mocked requests, and position limit errors
- Register the new binance_execution module in the existing test suite

Chores:
- Add trailing newlines to JSON files for consistent formatting